### PR TITLE
Added support for failed payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Now you will see a form like this:
 ---
 I will explain **`Order Status`**, **`Checkout Label`** and **`Status`** here and rest of the fields are explained in next sections:  
 
-- **Order Status**:  This is the default status of an order, set its value to **Pending**. After successful payment its value for a particular order will be **Processing**.
+- **Order Status**:  This is the order of the status that you would like to set after a **successful** payment.
 - **Checkout Label**: This is the label users will see during checkout, its default value is **"Pay using Instamojo"**. You can change it to somethint more generic like **"Pay using Credit/Debit Card or Online Banking"**.
 - **Status**:  This is the current status of the module. To use Instamojo during checkout make sure to change it to **enabled**.
 
@@ -79,3 +79,8 @@ This module will everything to a file named **imojo.log** under **system/logs**.
 
 ---
 <sub>`*` This may be different for your **Checkout Label** is different.</sub>
+
+### Support
+---
+
+If you're facing some issue with plugin integration then open an ticket at http://support.instamojo.com/. Please do include a **screenshot of the settings** you've done for the plugin in your admin backend as well as the **URL of the Instamojo payment link** you're using with the plugin.

--- a/upload/admin/controller/payment/instamojo.php
+++ b/upload/admin/controller/payment/instamojo.php
@@ -27,6 +27,8 @@ class ControllerPaymentInstamojo extends Controller {
     $data['text_disabled'] = $this->language->get('text_disabled');
     $data['text_edit'] = $this->language->get('text_edit');
     $data['entry_status'] = $this->language->get('entry_status');
+    $data['entry_sort_order'] = $this->language->get('entry_sort_order');
+    
  
     $data['action'] = $this->url->link('payment/instamojo', 'token=' . $this->session->data['token'], 'SSL');
     $data['cancel'] = $this->url->link('extension/payment', 'token=' . $this->session->data['token'], 'SSL');
@@ -77,6 +79,12 @@ class ControllerPaymentInstamojo extends Controller {
       $data['instamojo_order_status_id'] = $this->request->post['instamojo_order_status_id'];
     } else {
       $data['instamojo_order_status_id'] = $this->config->get('instamojo_order_status_id');
+    }
+
+    if (isset($this->request->post['instamojo_sort_order'])) {
+      $data['instamojo_sort_order'] = $this->request->post['instamojo_sort_order'];
+    } else {
+      $data['instamojo_sort_order'] = $this->config->get('instamojo_sort_order');
     }
  
     $this->load->model('localisation/order_status');

--- a/upload/admin/language/english/payment/instamojo.php
+++ b/upload/admin/language/english/payment/instamojo.php
@@ -14,6 +14,7 @@ $_['instamojo_custom_field'] = 'Custom Field';
 
 $_['entry_status'] = 'Status';
 $_['entry_order_status'] = 'Order Status';
+$_['entry_sort_order'] = 'Sort Order';
  
 $_['text_button_save'] = 'Save';
 $_['text_button_cancel'] = 'Cancel';

--- a/upload/admin/view/template/payment/instamojo.tpl
+++ b/upload/admin/view/template/payment/instamojo.tpl
@@ -34,6 +34,14 @@
               </select>
             </div>
           </div>
+
+          <div class="form-group">
+            <label class="col-sm-2 control-label" for="input-sort-order"><?php echo $entry_sort_order; ?></label>
+            <div class="col-sm-10">
+              <input type="text" name="instamojo_sort_order" value="<?php echo $instamojo_sort_order; ?>" id="input-sort-order" class="form-control" />
+            </div>
+          </div>
+
           <div class="form-group">
             <label class="col-sm-2 control-label" for="input-sort-order"><?php echo $entry_text_instamojo_checkout_label; ?></label>
             <div class="col-sm-10">

--- a/upload/catalog/controller/payment/instamojo.php
+++ b/upload/catalog/controller/payment/instamojo.php
@@ -28,7 +28,7 @@ class ControllerPaymentInstamojo extends Controller {
 
       $name = substr(trim((html_entity_decode($order_info['shipping_firstname'] . ' ' . $order_info['shipping_lastname'], ENT_QUOTES, 'UTF-8'))), 0, 20);
       $email = substr($order_info['email'], 0, 75);
-      $phone = substr(ltrim(html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8'), '+'), 0, 20);
+      $phone = substr(html_entity_decode($order_info['telephone'], ENT_QUOTES, 'UTF-8'), 0, 20);
       $amount = $this->currency->format($order_info['total'], $order_info['currency_code'] , false, false);
       $orderid = date('His') . '-' . $this->session->data['order_id'];
 
@@ -82,8 +82,7 @@ class ControllerPaymentInstamojo extends Controller {
       $payment_status = $data['payment']['status'];
       $this->logger->write("Response from server is $payment_status.");
 
-      if($payment_status === "Credit"){
-        $this->logger->write("Payment for $payment_id was credited.");
+      if($payment_status === "Credit" || $payment_status === "Failed" || $payment_status === "Initiated"){
         $custom_field = $this->config->get('instamojo_custom_field');
         $tr_ord_id = $data['payment']['custom_fields'][$custom_field]['value'];
         $time_order_id = explode('-',  $tr_ord_id);
@@ -91,28 +90,34 @@ class ControllerPaymentInstamojo extends Controller {
         $this->load->model('checkout/order');
         $order_info = $this->model_checkout_order->getOrder($order_id);
 
-        if ($order_info) {
-          $this->model_checkout_order->addOrderHistory($order_id, 2);
-          $this->response->redirect($this->url->link('checkout/success', '', 'SSL'));
-        }
-        else{
-          
-          $this->logger->write("Couldn't find any order for Payment ID $payment_id. Please contact the site admin for enquiries.");
-          $this->response->redirect($this->url->link('checkout/cart', '', 'SSL'));
+        if($order_info){
+
+          if($payment_status == "Credit"){
+              $this->logger->write("Payment for $payment_id was credited.");
+              $this->model_checkout_order->addOrderHistory($order_id, $this->config->get('instamojo_order_status_id'), "Payment successful for instamojo payment ID: $payment_id", true);
+              $this->response->redirect($this->url->link('checkout/success', '', 'SSL'));
+            }
+            else if($payment_status == "Failed"){
+              $this->logger->write("Payment for $payment_id failed.");
+              $this->model_checkout_order->addOrderHistory($order_id, 10, "Payment failed for instamojo payment ID: $payment_id", true);
+              $this->response->redirect($this->url->link('checkout/cart', '', 'SSL'));
+
+            }
+            else if($payment_status == "Initiated"){
+              $this->logger->write("Payment for $payment_id failed(initiated).");
+              $this->model_checkout_order->addOrderHistory($order_id, 10, "Payment initiated for instamojo payment ID but never completed: $payment_id", true);
+              $this->response->redirect($this->url->link('checkout/cart', '', 'SSL'));
+            }
         }
 
       }
       else{
         $this->logger->write("Payment for $payment_id was not credited.");
         $this->response->redirect($this->url->link('checkout/cart', '', 'SSL'));
-        //$this->response->redirect($this->url->link('checkout/cart', '', 'SSL'));
-        //$method_data['insta_error'] = "Either $payment_id is is an invalid Payment ID or the payment for it was unsuccessful. Please contact the site admin for enquiries.";
-
       } 
     } else {
       $this->logger->write("Callback called with no payment ID.");
       $this->response->redirect($this->config->get('config_url'));
-      //die('Illegal Access');
     }
   
   }
@@ -121,7 +126,7 @@ class ControllerPaymentInstamojo extends Controller {
   private function _getcurlInfo($payment_id){
 
     $this->logger->write("Get the required field for payment ID: $payment_id");
-    $cUrl = 'https://www.instamojo.com/api/1.1/payments/' . $payment_id;
+    $cUrl = 'https://www.instamojo.com/api/1.1/payments/' . $payment_id . '/';
     $api_key = $this->config->get('instamojo_api_key');
     $auth_token = $this->config->get('instamojo_auth_token');
     $ch = curl_init();


### PR DESCRIPTION
- Fixed the issue of **Order Status** field, now it is going to be used to set the status of a successful order.
- Let's not trim out `+` from the phone numbers
- Added support for failed payments.
- Added sort option.
- Added trailing `/` to payment detail API request to prevent a rare cURL error.
